### PR TITLE
Bugfix/issue 28

### DIFF
--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -176,9 +176,9 @@ export default function Home() {
                 />
                 あなたに残された時間
               </Typography>
-              <Typography sx={{ fontSize: "1.5rem" }}>
+              <Box sx={{ fontSize: "1.5rem" }}>
                 <RemainingLife key={remainingLifeKey} person={person} />
-              </Typography>
+              </Box>
             </Box>
           )}
         </Box>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -47,6 +47,7 @@ export default function Home() {
   const [selectBirthDate, setSelectBirthDate] = useState<Date | null>(null);
   const [selectSex, setSelectSex] = useState<sexType | "">("");
   const [showModal, setShowModal] = useState(false);
+  const [remainingLifeKey, setRemainingLifeKey] = useState<number>(0);
 
   const handleChangeSex = (e: SelectChangeEvent<sexType>) => {
     setSelectSex(e.target.value as sexType);
@@ -75,6 +76,9 @@ export default function Home() {
       setSelectBirthDate(null);
       setSelectSex("");
       setShowModal(false);
+
+      // 再作成したRemainingLifeコンポーネントのkeyを更新
+      setRemainingLifeKey((prevKey) => prevKey + 1);
     } catch (err) {
       console.error("err: ", err);
     }
@@ -173,7 +177,7 @@ export default function Home() {
                 あなたに残された時間
               </Typography>
               <Typography sx={{ fontSize: "1.5rem" }}>
-                <RemainingLife person={person} />
+                <RemainingLife key={remainingLifeKey} person={person} />
               </Typography>
             </Box>
           )}


### PR DESCRIPTION
#28 
## 対応内容
 - frontend/src/pages/index.tsxで表示するRemainingLifeにkeyを付与し、新規表示する余命のみを表示の対象に変更。
 - RemainingLifeコンポーネントの親要素をTypographyからBoxに変更。

## 事象説明
 - 余命表示のバグ原因は不明であった。
   - 以前に表示した余命と今回表示する余命が交互に表示されていた。
   - そのため、RemainingLifeにkeyを付与して一意な余命のみを表示するように修正した。
 - devタグの親要素がpタグである場合にエラーが発生する。
   - Typographyコンポーネントがどのように認識されるかは環境により異なるが、今回はBoxに修正することで対応した。