### PR TITLE
Fix/birthdate limit

### DIFF
--- a/backend/validators/createPersonSchema.js
+++ b/backend/validators/createPersonSchema.js
@@ -7,9 +7,11 @@ const createPersonSchema = Joi.object({
     "string.max": "名前は15文字以内で入力してください",
   }),
 
-  birthDate: Joi.date().required().messages({
+  birthDate: Joi.date().min("1900-01-01").max(new Date()).required().messages({
     "any.required": "生年月日を指定してください",
     "date.base": "有効な日付を指定してください",
+    "date.min": "生年月日は 1900/01/01〜本日 の範囲で選択してください",
+    "date.max": "生年月日は 1900/01/01〜本日 の範囲で選択してください",
   }),
 
   sex: Joi.string().trim().required().messages({

--- a/backend/validators/editPersonSchema.js
+++ b/backend/validators/editPersonSchema.js
@@ -14,10 +14,16 @@ const editPersonSchema = Joi.object({
       "string.max": "名前は15文字以内で入力してください",
     }),
 
-    birthDate: Joi.date().required().messages({
-      "any.required": "生年月日を指定してください",
-      "date.base": "有効な日付を指定してください",
-    }),
+    birthDate: Joi.date()
+      .min("1900-01-01")
+      .max(new Date())
+      .required()
+      .messages({
+        "any.required": "生年月日を指定してください",
+        "date.base": "有効な日付を指定してください",
+        "date.min": "生年月日は 1900/01/01〜本日 の範囲で選択してください",
+        "date.max": "生年月日は 1900/01/01〜本日 の範囲で選択してください",
+      }),
 
     sex: Joi.string().trim().required().messages({
       "any.required": "性別を指定してください",

--- a/backend/validators/signinSchema.js
+++ b/backend/validators/signinSchema.js
@@ -9,6 +9,8 @@ const signinSchema = Joi.object({
   password: Joi.string().trim().required().messages({
     "any.required": "パスワードを入力してください",
     "string.empty": "パスワードを指定してください",
+    "date.min": "生年月日は 1900/01/01〜本日 の範囲で選択してください",
+    "date.max": "生年月日は 1900/01/01〜本日 の範囲で選択してください",
   }),
 });
 

--- a/backend/validators/signupSchema.js
+++ b/backend/validators/signupSchema.js
@@ -21,9 +21,11 @@ const signupSchema = Joi.object({
       "パスワードは英字と数字の組み合わせで、8文字以上10文字以内で入力してください",
   }),
 
-  birthDate: Joi.date().required().messages({
+  birthDate: Joi.date().min("1900-01-01").max(new Date()).required().messages({
     "any.required": "生年月日を指定してください",
     "date.base": "有効な日付を指定してください",
+    "date.min": "生年月日は 1900/01/01〜本日 の範囲で選択してください",
+    "date.max": "生年月日は 1900/01/01〜本日 の範囲で選択してください",
   }),
 
   sex: Joi.string().trim().required().messages({

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -17,6 +17,7 @@ import HistoryToggleOffIcon from "@mui/icons-material/HistoryToggleOff";
 import PageHead from "../../components/PageHead";
 import { useRecoilValue } from "recoil";
 import userAtom from "../../recoil/atom/userAtoms";
+import { useRouter } from "next/router";
 
 type sexType = "male" | "female";
 
@@ -42,6 +43,7 @@ type personType = {
 
 export default function Home() {
   const user = useRecoilValue(userAtom);
+  const router = useRouter();
 
   const [person, setPerson] = useState<personType>(null);
   const [selectBirthDate, setSelectBirthDate] = useState<Date | null>(null);
@@ -68,11 +70,35 @@ export default function Home() {
         return alert("情報を設定してください");
       }
 
+      // バリデーション
+      const currentDate = new Date(new Date().toDateString());
+      const minBirthDate = new Date(new Date("1900-01-01").toDateString());
+
+      // 生年月日：形式確認
+      if (isNaN(selectBirthDate.getTime())) {
+        return alert("正しい生年月日を入力してください");
+      }
+
+      // 生年月日：範囲確認
+      const sanitizedBirthDate = new Date(selectBirthDate.toDateString()); // 比較のために時刻をクリア
+      if (
+        sanitizedBirthDate < minBirthDate ||
+        currentDate < sanitizedBirthDate
+      ) {
+        return alert("生年月日が範囲外です（1900年1月1日〜本日）");
+      }
+
+      // 性別：値確認
+      if (selectSex !== "male" && selectSex !== "female") {
+        return alert("性別を選択してください（maleまたはfemale）");
+      }
+
       setPerson({
         birthDate: selectBirthDate,
         sex: selectSex,
       });
 
+      // 初期化
       setSelectBirthDate(null);
       setSelectSex("");
       setShowModal(false);
@@ -80,7 +106,7 @@ export default function Home() {
       // 再作成したRemainingLifeコンポーネントのkeyを更新
       setRemainingLifeKey((prevKey) => prevKey + 1);
     } catch (err) {
-      console.error("err: ", err);
+      router.push("/");
     }
   };
 
@@ -195,6 +221,7 @@ export default function Home() {
                       value={selectBirthDate}
                       onChange={handleChangeBirth}
                       maxDate={new Date()}
+                      minDate={new Date("1900-01-01")}
                     />
                   </Box>
                   <Box sx={{ marginBottom: "10px" }}>


### PR DESCRIPTION
#35 
 - 設定する生年月日の範囲を以下の通り実装した。(サーバサイド)
   - 下限: 1900/01/01
   - 上限: サイト利用日当日
 - トップページで選択する生年月日は、サーバを介さずにフロントエンドで実装した。